### PR TITLE
Store Account in session rather than default UserDetails

### DIFF
--- a/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/AccountController.java
+++ b/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/AccountController.java
@@ -59,7 +59,7 @@ public class AccountController {
 
     @GetMapping("/me")
     public ResponseEntity<MeResponse> getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
-        Account account = accountService.account(userDetails.getUsername());
+        Account account = (Account) userDetails;
         return ResponseEntity.ok(new MeResponse(account.firstName(), account.lastName(), account.email()));
     }
 

--- a/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/AccountService.java
+++ b/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/AccountService.java
@@ -37,9 +37,4 @@ public class AccountService implements IAccountService {
         accountRepository.create(email, hashedPassword, firstName, lastName);
     }
 
-    @Override
-    public Account account(String email) {
-        return accountRepository.get(email);
-    }
-
 }

--- a/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/IAccountService.java
+++ b/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/account/IAccountService.java
@@ -1,11 +1,9 @@
 package com.asd.board_game_statistics_api.account;
 
 import com.asd.board_game_statistics_api.account.exceptions.CreateAccountException;
-import com.asd.board_game_statistics_api.model.Account;
 
 public interface IAccountService {
 
     void createAccount(String email, String password, String firstName, String lastName) throws CreateAccountException;
-    Account account(String email);
 
 }

--- a/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/config/DbUserDetailsService.java
+++ b/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/config/DbUserDetailsService.java
@@ -25,10 +25,7 @@ public class DbUserDetailsService implements UserDetailsService {
             throw new UsernameNotFoundException("Account not found");
         }
 
-        return User.withUsername(account.email())
-                .password(account.password())
-                .roles("USER")
-                .build();
+        return account;
     }
 
 }

--- a/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/model/Account.java
+++ b/board-game-statistics-api/src/main/java/com/asd/board_game_statistics_api/model/Account.java
@@ -1,9 +1,33 @@
 package com.asd.board_game_statistics_api.model;
 
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
 
-public record Account(int id, String email, String password, String firstName, String lastName) {
+public record Account(int id, String email, String password, String firstName, String lastName) implements UserDetails {
+
+    private static final Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
     public static Account fromResultSet(ResultSet rs) throws SQLException {
         if (!rs.next()) return null;
         return new Account(
@@ -14,4 +38,5 @@ public record Account(int id, String email, String password, String firstName, S
                 rs.getString("last_name")
         );
     }
+
 }


### PR DESCRIPTION
This allows the `UserDetails` object to be cast to an `Account` from any controller, rather than fetching the account from the database using the username on every request.

See the change to the `/api/account/me` endpoint to see an example.